### PR TITLE
fix issue #125 单集群使用 Kubeprober案例

### DIFF
--- a/deployment/probe-agent-standalone.yaml
+++ b/deployment/probe-agent-standalone.yaml
@@ -4373,7 +4373,7 @@ roleRef:
   name: kubeprober-worker-role
 subjects:
 - kind: ServiceAccount
-  name: kubeprober-worker
+  name: kubeprober
   namespace: kubeprober
 ---
 apiVersion: v1
@@ -4432,7 +4432,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: kubeprober/probe-agent:v0.1.0-beta6
+        image: kubeprober/probe-agent:v0.1.0-beta11
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -4465,3 +4465,14 @@ spec:
       - configMap:
           name: probeagent
         name: probe-config-volume
+---
+apiVersion: v1
+data:
+  probe-conf.yaml: |
+    cluster_name: moon
+    agent_debug: false
+    debug_level: 1
+kind: ConfigMap
+metadata:
+  name: probeagent
+  namespace: kubeprober

--- a/deployment/probe-agent-standalone.yaml
+++ b/deployment/probe-agent-standalone.yaml
@@ -4476,3 +4476,12 @@ kind: ConfigMap
 metadata:
   name: probeagent
   namespace: kubeprober
+---
+# fix for prober-demo-example
+apiVersion: v1
+data:
+  test: moon
+kind: ConfigMap
+metadata:
+  name: extra-config
+  namespace: kubeprober


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
fix for https://docs.erda.cloud/2.0/manual/eco-tools/kubeprober/best-practices/standalone_kubeprober.html

#### Which issue(s) this PR fixes:

- Fixes #125 

#### Need cherry-pick to release versions?
depend on repository owner